### PR TITLE
Use .items() instead of .iteritems()

### DIFF
--- a/flask_graylog.py
+++ b/flask_graylog.py
@@ -118,7 +118,7 @@ class Graylog(logging.Logger):
                 'remote_addr': request.environ.get('REMOTE_ADDR'),
                 'headers': dict(
                     (key[5:].replace('-', '_').lower(), value)
-                    for key, value in request.environ.iteritems()
+                    for key, value in request.environ.items()
                     if key.startswith('HTTP_') and key.lower() not in ('http_cookie', )
                 )
             },


### PR DESCRIPTION
Fixes #1 

`.iteritems()` does not exist in Python 3, the behavior of `.iteritems()` is just `.items()` for dicts.

This appears to have been the only non-python3 part of the library.
