### PR TITLE
Config dictionary ingnored bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 dist/
 *.pyc
+.idea/

--- a/flask_graylog.py
+++ b/flask_graylog.py
@@ -26,7 +26,7 @@ class Graylog(logging.Logger):
 
         # If we have an app, then call `init_app` automatically
         if app is not None:
-            self.init_app(app)
+            self.init_app(app, self.config)
 
     def init_app(self, app, config=None):
         """


### PR DESCRIPTION
Fixes wrong logic of not saving passed config and overwriting it with app config instead. Config passed as a dict should have highest priority.